### PR TITLE
added cookie settings to prevent popup

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,7 +54,8 @@ def save_as_pdf(url, dest):
     title_from_url = url.split('/')[-2].replace(' ', '_')
     title_prettified = ' '.join([i.capitalize() for i in title_from_url.split('-')])
     title = dest + str(index) + ' ' + title_prettified + '.pdf'
-    pdfkit.from_url(url, title)
+    options = {'cookie': [('ezCMPCookieConsent', '-1=1|1=1|2=1|3=1|4=1')]}
+    pdfkit.from_url(url, title, options=options)
     index += 1
 
 


### PR DESCRIPTION
In my region learncpp.com asks for cookie permission when you enter the page so every generated pdf will have this popup on top. to prevent this i copied the cookie settings from my browser and transmit it with every pdfkit request and the popup is gone.