### PR TITLE
Adding missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+brotli==1.1.0
+mutagen==1.47.0
+pycryptodomex==3.20.0
+websockets==12.0
 attrs==23.2.0
 Automat==22.10.0
 beautifulsoup4==4.12.3


### PR DESCRIPTION
Fixing error while installing the requirements:
```bash
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
yt-dlp 2023.12.30 requires brotli; implementation_name == "cpython", which is not installed.
yt-dlp 2023.12.30 requires mutagen, which is not installed.
yt-dlp 2023.12.30 requires pycryptodomex, which is not installed.
yt-dlp 2023.12.30 requires websockets>=12.0, which is not installed.
```